### PR TITLE
Introduced CLI options for both file path and language code.

### DIFF
--- a/sbox.py
+++ b/sbox.py
@@ -1,5 +1,5 @@
 # coded by sameera madushan
-
+import argparse
 import os
 import re
 import time
@@ -9,19 +9,6 @@ import platform
 import sys
 from pathlib import Path
 
-
-banner = r'''
-     ___     ___     ___   __  __  
-    / __|   | _ )   / _ \  \ \/ /  
-    \__ \   | _ \  | (_) |  >  <   
-    |___/   |___/   \___/  /_/\_\  
-    _|"""""|_|"""""|_|"""""|_|"""""| 
-    "`-0-0-'"`-0-0-'"`-0-0-'"`-0-0-'  
-             Subtitles BOX    
-'''
-
-print(banner)
-time.sleep(1)
 
 def tk_get_file_path():
     try:
@@ -44,8 +31,9 @@ def tk_get_file_path():
 
     return file_path
 
+
 # got this from https://stackoverflow.com/a/58861718/13276219
-def file_path():
+def get_file_path():
     # Get operating system
     operating_system = platform.system()
 
@@ -71,8 +59,6 @@ def file_path():
         return tk_get_file_path()
 
 
-file_path = file_path()
-
 languages = {
     "en" : "English",
     "es" : "Spanish",
@@ -86,6 +72,7 @@ languages = {
     "tr" : "Turkish"
 }
 
+
 def get_hash(name):
     readsize = 64 * 1024
     with open(name, 'rb') as f:
@@ -95,13 +82,15 @@ def get_hash(name):
         data += f.read(readsize)
     return hashlib.md5(data).hexdigest()
 
-def create_url():
+
+def create_url(file_path):
     film_hash = get_hash(name=file_path)
     url = "http://api.thesubdb.com/?action=search&hash={}".format(film_hash)
     return url
 
-def request_subtitile():
-    url = create_url()
+
+def request_subtitle(file_path):
+    url = create_url(file_path)
     header = { "user-agent": "SubDB/1.0 (SubtitleBOX/1.0; https://github.com/sameera-madushan/SubtitleBOX.git)" }
     req = requests.get(url, headers=header)
     if req.status_code == 200:
@@ -117,36 +106,66 @@ def request_subtitile():
         print("Oops!! Subtitle not found.")
         exit()
 
-def download(data):
+
+def download(file_path, data):
     # from https://www.reddit.com/user/panzerex/
     filename = Path(file_path).with_suffix('.srt')
     with open(filename, 'wb') as f:
         f.write(data)
     f.close()
 
-request_subtitile()
 
-while True:
-    try:
-        select_langauge = input("\nChoose your langauge (Please use language codes): ").lower()
-        if select_langauge in l:
-            url = create_url()
-            search = re.sub(r'search', "download", url)
-            final_url = search + "&language={}".format(select_langauge)
-            header = { "user-agent": "SubDB/1.0 (SubtitleBOX/1.0; https://github.com/sameera-madushan/SubtitleBOX.git)" }
-            req = requests.get(final_url, headers=header)
-            if req.status_code == 200:
-                data = req.content
-                download(data=data)
-                print("\nSubtitle downloaded successfully")
-                break
-            else:
-                print("\nUnknown Error")
-                break
+def main(cli_file_path, language_code_cli):
+    banner = r'''
+         ___     ___     ___   __  __  
+        / __|   | _ )   / _ \  \ \/ /  
+        \__ \   | _ \  | (_) |  >  <   
+        |___/   |___/   \___/  /_/\_\  
+        _|"""""|_|"""""|_|"""""|_|"""""| 
+        "`-0-0-'"`-0-0-'"`-0-0-'"`-0-0-'  
+                 Subtitles BOX    
+    '''
+
+    print(banner)
+    time.sleep(1)
+
+    if cli_file_path == "":
+        file_path = get_file_path()
+    else:
+        file_path = cli_file_path
+
+    request_subtitle(file_path)
+    if language_code_cli == "":
+        select_language = input("\nChoose your language (Please use language codes): ").lower()
+    else:
+        select_language = language_code_cli
+
+    if select_language in l:
+        url = create_url(file_path)
+        search = re.sub(r'search', "download", url)
+        final_url = search + "&language={}".format(select_language)
+        header = { "user-agent": "SubDB/1.0 (SubtitleBOX/1.0; https://github.com/sameera-madushan/SubtitleBOX.git)" }
+        req = requests.get(final_url, headers=header)
+        if req.status_code == 200:
+            data = req.content
+            download(file_path=file_path, data=data)
+            print("\nSubtitle downloaded successfully")
         else:
-            print("\nInvalid language code selected. Please try again.")
-            
-    except KeyboardInterrupt:
-        print("\nProgramme Interrupted")
-        break
-        
+            print("\nUnknown Error")
+    else:
+        print("\nInvalid language code selected. Please try again.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='SubtitleBOX CLI')
+    parser.add_argument("--file_path", default="",
+                        help="Path of the video file for which subtitles should be looked for")
+    parser.add_argument("--language_code", default="",
+                        help="Language code for subtitles. Can be en, es, fr, it, nl, pl, pt, ro, sv, tr")
+
+    args = parser.parse_args()
+
+    main(args.file_path, args.language_code)
+
+
+


### PR DESCRIPTION
Hello,

I found your script very useful. However, I found it boring to add every single file by hand, and selecting more files at once did not work.
So, I thought that it would be useful if the app could take as CLI input also the name of the video file and the language code.
This way, you can automatize the work of getting subs for many files at once:

```
#!/bin/bash
for entry in ./*
do
  python sbox.py --file_path "$entry" --language_code "en"
done
```
If you do NOT specify the file path and the language code, the application should work identically as before (showing the GUI), at least so it does on my platform.

A bit of work should be done to treat the exceptions gracefully. For example, if you specify a wrong file name (not existent) or a wrong language code, or if the language is not available for that particular file.
Also, the script could be made less verbose if used in CLI.


Thank you!