### PR TITLE
Add numpy to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ chardet==3.0.4
 idna==2.9
 requests==2.23.0
 urllib3==1.25.8
+numpy==1.18


### PR DESCRIPTION
I found numpy was missing from the `requirements.txt` file when I tried running the script. I added the latest version of numpy: 1.18.