### PR TITLE
Fix for locales not found if the script is invoked from another path

### DIFF
--- a/sbox.py
+++ b/sbox.py
@@ -14,13 +14,14 @@ from os import path
 from pathlib import Path
 from tkinter import Tk, filedialog
 
+locales_path = sys.path[0] + '/locales'
 try:
     user_locale = locale.getdefaultlocale()[0]
-    lang = gettext.translation('messages', localedir='locales', languages=[user_locale])
+    lang = gettext.translation('messages', localedir=locales_path, languages=[user_locale])
     lang.install()
     _ = lang.gettext
 except FileNotFoundError:
-    lang = gettext.translation('messages', localedir='locales', languages=["en_US"])
+    lang = gettext.translation('messages', localedir=locales_path, languages=["en_US"])
     lang.install()
     _ = lang.gettext
 


### PR DESCRIPTION
It's a fix for the script to look for locales in the folder in which the script is, instead of looking in the one from which the script is invoked.

For example, if I am in a folder which contains movies and I invoked the script, which is in a different folder, an error would h appen.

Have a nice day!